### PR TITLE
Managing ES authentication both from env var and uri params

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ elasticsearch:
     - /news/*
 ```
 
+### ES Auth
+Elasticsearch authentication can be provided both by passing user and password as URI parameter:
+```yaml
+url: https://user:pass@someurl.com
+```
+Or by easily setting those ENV variables:
+```sh
+ELASTICSEARCH_URL=http://localhost:9200/
+ELASTICSEARCH_USER=elastic
+ELASTICSEARCH_UPASS=changeme
+```
+
 ### Custom Settings File Example
 
 It should be written to be plugged into the `settings` slot of a [create index](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html) call

--- a/lib/searchyll/configuration.rb
+++ b/lib/searchyll/configuration.rb
@@ -11,6 +11,12 @@ module Searchyll
       ENV['BONSAI_URL'] || ENV['ELASTICSEARCH_URL'] ||
         ((site.config||{})['elasticsearch']||{})['url']
     end
+    def elasticsearch_user
+      ENV['ELASTICSEARCH_USER']
+    end
+    def elasticsearch_pass
+      ENV['ELASTICSEARCH_PASS']
+    end
 
     def valid?
       elasticsearch_url && !elasticsearch_url.empty? && elasticsearch_url.start_with?('http')

--- a/lib/searchyll/indexer.rb
+++ b/lib/searchyll/indexer.rb
@@ -19,6 +19,8 @@ module Searchyll
     attr_accessor :queue
     attr_accessor :timestamp
     attr_accessor :uri
+    attr_accessor :es_user
+    attr_accessor :es_pass
     attr_accessor :working
     attr_accessor :ignore_regex
 
@@ -27,6 +29,8 @@ module Searchyll
     def initialize(configuration)
       self.configuration = configuration
       self.uri           = URI(configuration.elasticsearch_url)
+      self.es_user       = configuration.elasticsearch_user
+      self.es_pass       = configuration.elasticsearch_pass
       self.queue         = Queue.new
       self.working       = true
       self.timestamp     = Time.now
@@ -159,8 +163,12 @@ module Searchyll
       req = klass.new(path)
       req.content_type = 'application/json'
       req['Accept']    = 'application/json'
-      # Append auth credentials if the exist
-      req.basic_auth(uri.user, uri.password) if uri.user && uri.password
+      # Append auth credentials if they exist
+      # it trying to get them from env and then from
+      # elasticsearch uri itself
+      user = es_user || uri.user
+      pass = es_pass || uri.password
+      req.basic_auth(user, pass) if user && pass
       req
     end
 


### PR DESCRIPTION
Elasticsearch authentication can be provided both by passing user and password as URI parameter:
```yaml
url: https://user:pass@someurl.com
```
Or by easily setting those ENV variables:
```sh
ELASTICSEARCH_URL=http://localhost:9200/
ELASTICSEARCH_USER=elastic
ELASTICSEARCH_UPASS=changeme
```